### PR TITLE
Use vale.a (not aes.o); Fix path to kremlib.h.

### DIFF
--- a/secure_api/Makefile
+++ b/secure_api/Makefile
@@ -39,7 +39,7 @@ MAIN_FILES=
 vale/asm/vale.a:
 	make -C vale/asm
 
-LowCProvider-tmp: vale/aes/aes.o
+LowCProvider-tmp: vale/asm/vale.a
 	$(KRML) LowCProvider/Crypto.Indexing.fst \
 		test/Flag.fst utils/Hacl.Spec.fst \
 		aead/Crypto.AEAD.fst \

--- a/secure_api/vale/asm/Makefile
+++ b/secure_api/vale/asm/Makefile
@@ -21,8 +21,8 @@ else ifeq ($(UNAME),Linux)
 endif
 
 
-VALE_HOME?=../../../vale
-KREMLIN_HOME?=../../../kremlin
+VALE_HOME?=../../../../vale
+KREMLIN_HOME?=../../../../kremlin
 CCOPTS=-Wall -Wextra -Werror -I$(KREMLIN_HOME)/kremlib
 CC:=$(CC) $(CCOPTS)
 


### PR DESCRIPTION
everest-ci/ci's fetch_hacl_for_mitls `make -C secure_api/LowCProvider` currently doesn't build. This should fix it. 
First time changing code in hacl*. @jkzinzindohoue and @protz: can you check please? 