### PR TITLE
Update Makefile so even the static library is cleared

### DIFF
--- a/snapshots/hacl-c/Makefile
+++ b/snapshots/hacl-c/Makefile
@@ -145,4 +145,4 @@ unit-tests32: libhacl32.so
 	LD_LIBRARY_PATH=. DYLD_LIBRARY_PATH=. ./unit_tests32.exe
 
 clean:
-	rm -rf *~ *.exe *.out *.o *.txt *.so
+	rm -rf *~ *.exe *.out *.o *.txt *.so *.a


### PR DESCRIPTION
Clears the static library generated in C snapshot directory