### PR TITLE
drop prefix in ed25519 sign_step_4 to avoid generating unused variables

### DIFF
--- a/code/ed25519/Hacl.Impl.Ed25519.Sign.Steps.fst
+++ b/code/ed25519/Hacl.Impl.Ed25519.Sign.Steps.fst
@@ -344,7 +344,6 @@ let sign_step_4 msg len tmp_bytes tmp_ints =
   let rs'  = Buffer.sub tmp_bytes 160ul 32ul in
   let apre = Buffer.sub tmp_bytes 224ul 64ul in
   let a      = Buffer.sub apre 0ul 32ul in
-  let prefix = Buffer.sub apre 32ul 32ul in
   let h0 = ST.get() in
   Hacl.Impl.SHA512.ModQ.sha512_modq_pre_pre2 h rs' a'' msg len;
   let h1 = ST.get() in

--- a/snapshots/hacl-c/Hacl_Chacha20_Vec128.c
+++ b/snapshots/hacl-c/Hacl_Chacha20_Vec128.c
@@ -194,11 +194,10 @@ inline static void Hacl_Impl_Chacha20_Vec128_chacha20_core3(vec *k0, vec *k1, ve
 
 inline static void Hacl_Impl_Chacha20_Vec128_chacha20_block(uint8_t *stream_block, vec *st)
 {
-  vec zero = vec_zero();
-  KRML_CHECK_SIZE(zero, (uint32_t)4U);
+  KRML_CHECK_SIZE(vec_zero(), (uint32_t)4U);
   vec k[4U];
   for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    k[_i] = zero;
+    k[_i] = vec_zero();
   Hacl_Impl_Chacha20_Vec128_chacha20_core(k, st);
   Hacl_Impl_Chacha20_Vec128_State_state_to_key_block(stream_block, k);
 }
@@ -255,30 +254,28 @@ static void Hacl_Impl_Chacha20_Vec128_xor_block(uint8_t *output, uint8_t *plain,
 
 static void Hacl_Impl_Chacha20_Vec128_update(uint8_t *output, uint8_t *plain, vec *st)
 {
-  vec zero = vec_zero();
-  KRML_CHECK_SIZE(zero, (uint32_t)4U);
+  KRML_CHECK_SIZE(vec_zero(), (uint32_t)4U);
   vec k[4U];
   for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    k[_i] = zero;
+    k[_i] = vec_zero();
   Hacl_Impl_Chacha20_Vec128_chacha20_core(k, st);
   Hacl_Impl_Chacha20_Vec128_xor_block(output, plain, k);
 }
 
 static void Hacl_Impl_Chacha20_Vec128_update3(uint8_t *output, uint8_t *plain, vec *st)
 {
-  vec zero = vec_zero();
-  KRML_CHECK_SIZE(zero, (uint32_t)4U);
+  KRML_CHECK_SIZE(vec_zero(), (uint32_t)4U);
   vec k0[4U];
   for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    k0[_i] = zero;
-  KRML_CHECK_SIZE(zero, (uint32_t)4U);
+    k0[_i] = vec_zero();
+  KRML_CHECK_SIZE(vec_zero(), (uint32_t)4U);
   vec k1[4U];
   for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    k1[_i] = zero;
-  KRML_CHECK_SIZE(zero, (uint32_t)4U);
+    k1[_i] = vec_zero();
+  KRML_CHECK_SIZE(vec_zero(), (uint32_t)4U);
   vec k2[4U];
   for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    k2[_i] = zero;
+    k2[_i] = vec_zero();
   Hacl_Impl_Chacha20_Vec128_chacha20_core3(k0, k1, k2, st);
   uint8_t *p0 = plain;
   uint8_t *p1 = plain + (uint32_t)64U;
@@ -380,11 +377,10 @@ Hacl_Impl_Chacha20_Vec128_chacha20(
   uint32_t ctr
 )
 {
-  vec zero = vec_zero();
-  KRML_CHECK_SIZE(zero, (uint32_t)4U);
+  KRML_CHECK_SIZE(vec_zero(), (uint32_t)4U);
   vec buf[4U];
   for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    buf[_i] = zero;
+    buf[_i] = vec_zero();
   vec *st = buf;
   Hacl_Impl_Chacha20_Vec128_init(st, k, n1, ctr);
   Hacl_Impl_Chacha20_Vec128_chacha20_counter_mode(output, plain, len, st);

--- a/snapshots/hacl-c/Hacl_Ed25519.c
+++ b/snapshots/hacl-c/Hacl_Ed25519.c
@@ -2760,7 +2760,6 @@ Hacl_Impl_Ed25519_Sign_Steps_sign_step_4(
   uint64_t *h = tmp_ints + (uint32_t)60U;
   uint8_t *a__ = tmp_bytes + (uint32_t)96U;
   uint8_t *rs_ = tmp_bytes + (uint32_t)160U;
-  uint8_t *apre = tmp_bytes + (uint32_t)224U;
   Hacl_Impl_SHA512_ModQ_sha512_modq_pre_pre2(h, rs_, a__, msg, len1);
 }
 

--- a/snapshots/hacl-c/vec128.h
+++ b/snapshots/hacl-c/vec128.h
@@ -1,3 +1,25 @@
+/* MIT License
+ *
+ * Copyright (c) 2016-2017 INRIA and Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 #ifndef __Vec_H
 #define __Vec_H
 


### PR DESCRIPTION
This generates `uint8_t *apre = tmp_bytes + (uint32_t)224U;`, which is unused.