### PR TITLE
Poly1305 32-bit for NSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,10 @@ verify-nss:
 	$(MAKE) ct -C code/poly1305
 	# Verification of poly1305 is disabled for now on Mozilla's CI.
 	# Verification is performed separately on every push in the Mozilla CI instead.
-	# $(MAKE) verify -C code/poly1305
+	$(MAKE) verify -C code/poly1305
 	$(MAKE) Spec.Poly1305.fst-verify -C specs
+	$(MAKE) ct -C code/poly1305_32
+	$(MAKE) verify -C code/poly1305_32
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,6 @@ verify-nss:
 	$(MAKE) verify -C code/salsa-family
 	$(MAKE) Spec.Chacha20.fst-verify -C specs
 	$(MAKE) ct -C code/poly1305
-	# Verification of poly1305 is disabled for now on Mozilla's CI.
-	# Verification is performed separately on every push in the Mozilla CI instead.
 	$(MAKE) verify -C code/poly1305
 	$(MAKE) Spec.Poly1305.fst-verify -C specs
 	$(MAKE) ct -C code/poly1305_32

--- a/Makefile.build
+++ b/Makefile.build
@@ -131,6 +131,7 @@ snapshots/nss: snapshots-remove-intermediates
 	cp snapshots/snapshot-gcc/Hacl_Chacha20.* snapshots/nss
 	cp snapshots/snapshot-gcc/Hacl_Chacha20_Vec128.* snapshots/nss
 	cp snapshots/snapshot-gcc/Hacl_Poly1305_64.* snapshots/nss
+	cp snapshots/snapshot-gcc/Hacl_Poly1305_32.* snapshots/nss
 	$(MAKE) snapshots/nss/kremlib
 	$(MAKE) snapshots/nss/specs
 


### PR DESCRIPTION
Add poly1305 32-bit to NSS targets.
I don't know why but it looks like the `make verify -C code/poly1305` works now in our CI so I added it back in.