### PR TITLE
ChaCha20 vec128 fixes for VS2015 32-bit

### DIFF
--- a/code/salsa-family/Hacl.Impl.Chacha20.Vec128.fst
+++ b/code/salsa-family/Hacl.Impl.Chacha20.Vec128.fst
@@ -186,7 +186,7 @@ val lemma_modifies_double_round3:
   st:state ->
   st':state{disjoint st st'} ->
   st'':state{disjoint st st' /\ disjoint st' st''} ->
-  Lemma (requires (live h0 st /\ live h0 st' /\ live h0 st'' /\ HyperStack.equal_domains h0 h1 /\ 
+  Lemma (requires (live h0 st /\ live h0 st' /\ live h0 st'' /\ HyperStack.equal_domains h0 h1 /\
     HyperStack.equal_domains h1 h2 /\ HyperStack.equal_domains h2 h3 /\
     modifies_1 st h0 h1 /\ modifies_1 st' h1 h2 /\ modifies_1 st'' h2 h3))
         (ensures (modifies_3 st st' st'' h0 h3))
@@ -592,8 +592,8 @@ val chacha20_sum3:
     (requires (fun h -> live h k0 /\ live h k1 /\ live h k2 /\ live h st /\ invariant log h st /\
       (match Ghost.reveal log with
       | MkLog k n ctr -> UInt32.v ctr < pow2 32 - 2 /\
-      as_state h k0 == Spec.rounds (Spec.setup k n (UInt32.v ctr)) /\ 
-      as_state h k1 == Spec.rounds (Spec.setup k n (UInt32.v ctr+1)) /\ 
+      as_state h k0 == Spec.rounds (Spec.setup k n (UInt32.v ctr)) /\
+      as_state h k1 == Spec.rounds (Spec.setup k n (UInt32.v ctr+1)) /\
       as_state h k2 == Spec.rounds (Spec.setup k n (UInt32.v ctr+2)) )))
     (ensures  (fun h0 updated_log h1 -> live h1 k0 /\ live h1 k1 /\ live h1 k2 /\ live h1 st /\
       invariant log h0 st /\
@@ -952,6 +952,7 @@ let lemma_uint32s_fragments3 st =
 
 #reset-options "--max_fuel 0 --z3rlimit 200"
 
+[@ "substitute"]
 val store_4_vec:
   output:uint8_p{length output = 64} ->
   v0:vec -> v1:vec -> v2:vec -> v3:vec ->
@@ -960,6 +961,7 @@ val store_4_vec:
     (ensures (fun h0 _ h1 -> live h0 output /\ live h1 output /\ modifies_1 output h0 h1 /\
       reveal_sbytes (as_seq h1 output) == FStar.Seq.(Spec.Lib.uint32s_to_le 16 (vec_as_seq v0 @| vec_as_seq v1 @|
                                                                 vec_as_seq v2 @| vec_as_seq v3)) ))
+[@ "substitute"]
 let store_4_vec output v0 v1 v2 v3 =
   let o0 = (Buffer.sub output 0ul  16ul) in
   let o1 = (Buffer.sub output 16ul 16ul) in
@@ -1119,7 +1121,7 @@ val lemma_live_update3:
         (ensures (live h1 buf /\ live h0 buf /\ as_seq h0 buf == as_seq h1 buf))
 let lemma_live_update3 h0 h1 st k0 k1 k2 buf =
   ()
-  
+
 
 val log_incrn:
   log:log_t -> m:UInt32.t -> Tot (log':log_t{match Ghost.reveal log, Ghost.reveal log' with
@@ -1205,7 +1207,7 @@ let update3 log output plain st =
   lemma_modifies_0_0 h1 h1'' h2;
   assert(live h2 plain);
   chacha20_core3 log k0 k1 k2 st;
-  let h3 = ST.get() in  
+  let h3 = ST.get() in
   lemma_live_update3 h2 h3 st k0 k1 k2 plain;
   lemma_live_update3 h2 h3 st k0 k1 k2 output;
   assert(live h3 plain);
@@ -1244,7 +1246,7 @@ let update3 log output plain st =
   no_upd_lemma_1 h3 h4 o0 k2;
   no_upd_lemma_1 h3 h4 o0 st;
   assert(as_seq h4 p1 == as_seq h0 p1);
-  assert(let ctr = (Ghost.reveal log).ctr in 
+  assert(let ctr = (Ghost.reveal log).ctr in
          let n   = (Ghost.reveal log).n in
          let k   = (Ghost.reveal log).k in
          flat_state_bytes h4 k1 == (Spec.chacha20_cipher k n (U32.v ctr+1)));
@@ -1258,7 +1260,7 @@ let update3 log output plain st =
   no_upd_lemma_1 h4 h5 o1 p2;
   no_upd_lemma_1 h4 h5 o1 k2;
   no_upd_lemma_1 h4 h5 o1 st;
-  assert(let ctr = (Ghost.reveal log).ctr in 
+  assert(let ctr = (Ghost.reveal log).ctr in
          let n   = (Ghost.reveal log).n in
          let k   = (Ghost.reveal log).k in
          flat_state_bytes h5 k2 == (Spec.chacha20_cipher k n (U32.v ctr+2)));

--- a/snapshots/hacl-c/Hacl_Chacha20_Vec128.c
+++ b/snapshots/hacl-c/Hacl_Chacha20_Vec128.c
@@ -222,19 +222,6 @@ Hacl_Impl_Chacha20_Vec128_update_last(uint8_t *output, uint8_t *plain, uint32_t 
   }
 }
 
-static void
-Hacl_Impl_Chacha20_Vec128_store_4_vec(uint8_t *output, vec v0, vec v1, vec v2, vec v3)
-{
-  uint8_t *o0 = output;
-  uint8_t *o1 = output + (uint32_t)16U;
-  uint8_t *o2 = output + (uint32_t)32U;
-  uint8_t *o3 = output + (uint32_t)48U;
-  vec_store_le(o0, v0);
-  vec_store_le(o1, v1);
-  vec_store_le(o2, v2);
-  vec_store_le(o3, v3);
-}
-
 static void Hacl_Impl_Chacha20_Vec128_xor_block(uint8_t *output, uint8_t *plain, vec *st)
 {
   vec p0 = vec_load_le(plain);
@@ -245,11 +232,18 @@ static void Hacl_Impl_Chacha20_Vec128_xor_block(uint8_t *output, uint8_t *plain,
   vec k1 = st[1U];
   vec k2 = st[2U];
   vec k3 = st[3U];
-  vec o0 = vec_xor(p0, k0);
-  vec o1 = vec_xor(p1, k1);
-  vec o2 = vec_xor(p2, k2);
-  vec o3 = vec_xor(p3, k3);
-  Hacl_Impl_Chacha20_Vec128_store_4_vec(output, o0, o1, o2, o3);
+  vec o00 = vec_xor(p0, k0);
+  vec o10 = vec_xor(p1, k1);
+  vec o20 = vec_xor(p2, k2);
+  vec o30 = vec_xor(p3, k3);
+  uint8_t *o0 = output;
+  uint8_t *o1 = output + (uint32_t)16U;
+  uint8_t *o2 = output + (uint32_t)32U;
+  uint8_t *o3 = output + (uint32_t)48U;
+  vec_store_le(o0, o00);
+  vec_store_le(o1, o10);
+  vec_store_le(o2, o20);
+  vec_store_le(o3, o30);
 }
 
 static void Hacl_Impl_Chacha20_Vec128_update(uint8_t *output, uint8_t *plain, vec *st)


### PR DESCRIPTION
It turns out VS2015 on 32-bit has problems with the `__m128i` in `store_4_vec` (they are not aligned). This should fix this issue.