### PR TITLE
Update CMakeLists.txt to add install targets for the libraries and the header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,28 @@ set(SOURCE_FILES_EXPERIMENTAL
    snapshots/hacl-c-experimental/drng.c
    snapshots/hacl-c-experimental/Hacl_Random.c)
 
+# Public header files
+set(HEADER_FILES
+    snapshots/hacl-c/AEAD_Poly1305_64.h
+    snapshots/hacl-c/FStar.h
+    snapshots/hacl-c/Hacl_Chacha20.h
+    snapshots/hacl-c/Hacl_Chacha20Poly1305.h
+    snapshots/hacl-c/Hacl_Chacha20_Vec128.h
+    snapshots/hacl-c/Hacl_Curve25519.h
+    snapshots/hacl-c/Hacl_Ed25519.h
+    snapshots/hacl-c/Hacl_HMAC_SHA2_256.h
+    snapshots/hacl-c/Hacl_Policies.h
+    snapshots/hacl-c/Hacl_Poly1305_32.h
+    snapshots/hacl-c/Hacl_Poly1305_64.h
+    snapshots/hacl-c/Hacl_Salsa20.h
+    snapshots/hacl-c/Hacl_SHA2_256.h
+    snapshots/hacl-c/Hacl_SHA2_384.h
+    snapshots/hacl-c/Hacl_SHA2_512.h
+    snapshots/hacl-c/kremlib_base.h
+    snapshots/hacl-c/kremlib.h
+    snapshots/hacl-c/NaCl.h
+    snapshots/hacl-c/vec128.h)
+
 # Define a user variable to determinate if experimental files are build
 option(Experimental "Include experimental code in HaCl build" OFF)
 
@@ -68,3 +90,11 @@ set_target_properties(hacl_shared PROPERTIES OUTPUT_NAME hacl)
 # Note: on Windows, depending on the build system,
 #       both static and shared can have the .lib extension
 #       (You can change the OUTPUT_NAME in that case...)
+
+set_target_properties(hacl_shared hacl_static PROPERTIES
+    PUBLIC_HEADER "${HEADER_FILES}")
+
+INSTALL(TARGETS hacl_shared hacl_static LIBRARY
+    DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    PUBLIC_HEADER DESTINATION "include/hacl")

--- a/snapshots/hacl-c/CMakeLists.txt
+++ b/snapshots/hacl-c/CMakeLists.txt
@@ -30,6 +30,28 @@ set(SOURCE_FILES_EXPERIMENTAL
    drng.c
    Random.c)
 
+# Public header files
+set(HEADER_FILES
+    AEAD_Poly1305_64.h
+    FStar.h
+    Hacl_Chacha20.h
+    Hacl_Chacha20Poly1305.h
+    Hacl_Chacha20_Vec128.h
+    Hacl_Curve25519.h
+    Hacl_Ed25519.h
+    Hacl_HMAC_SHA2_256.h
+    Hacl_Policies.h
+    Hacl_Poly1305_32.h
+    Hacl_Poly1305_64.h
+    Hacl_Salsa20.h
+    Hacl_SHA2_256.h
+    Hacl_SHA2_384.h
+    Hacl_SHA2_512.h
+    kremlib_base.h
+    kremlib.h
+    NaCl.h
+    vec128.h)
+
 # Define a user variable to determinate if experimental files are build
 option(Experimental "Include experimental code in HaCl build" OFF)
 
@@ -53,3 +75,11 @@ set_target_properties(hacl_shared PROPERTIES OUTPUT_NAME hacl)
 # Note: on Windows, depending on the build system,
 #       both static and shared can have the .lib extension
 #       (You can change the OUTPUT_NAME in that case...)
+
+set_target_properties(hacl_shared hacl_static PROPERTIES
+    PUBLIC_HEADER "${HEADER_FILES}")
+
+INSTALL(TARGETS hacl_shared hacl_static LIBRARY
+    DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    PUBLIC_HEADER DESTINATION "include/hacl")


### PR DESCRIPTION
This PR modifies the `CMakeLists.txt` in the `/snapshots/hacl-c` and in the `/` folders, so that when the Makefile is generated from them a `make install` target is created.

After a successful `make build` in the root directory, installing the compiled libraries is then just  a matter of `cd build && make install`.

The prefix for installation can be tweaked when calling cmake by invoking it as
`cmake -DCMAKE_INSTALL_PREFIX:PATH=/path/to/prefix ..`.

The static and the shared libraries are installed to `$PREFIX/lib` while the header files to `$PREFIX/include/hacl`.